### PR TITLE
travis: Ensure RubyGems is up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ rvm:
 
 gemfile:
   - Gemfile
+
+before_install:
+  - gem update --system
+  - gem install bundler


### PR DESCRIPTION
ruby 2.3.7 builds recently started failing with:

```
ruby-2.3.7 - #setup
ruby-2.3.7 - #gemset created /home/travis/.rvm/gems/ruby-2.3.7@global
ruby-2.3.7 - #importing gemset /home/travis/.rvm/gemsets/global.gems.................................there was an error installing gem bundler
................
```

(This happens in Travis' magical rvm init step, which we can't touch.)

I think these failures coincided with the release of bundler 2.0.0.
This release is dependent on RubyGems version >= 3.0.0.  The Travis RVM
gemset provides RubyGems 2.7.7.

I don't know why this is only impacting one build out of three.  Maybe
Travis is trying to install bundler 2.0.0 on ruby 2.3.7, but is using a
cache for the other builds (ruby 2.4.4 and 2.5.1)?