### PR TITLE
Run on Ruby 2.5; test only on Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.5.3
 
 gemfile:
   - Gemfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.5-alpine
 
 MAINTAINER Matt Palmer "matt.palmer@discourse.org"
 
@@ -19,7 +19,7 @@ ARG GIT_REVISION=invalid-build
 ENV MOBYSTASH_GIT_REVISION=$GIT_REVISION
 
 COPY bin/* /usr/local/bin/
-COPY lib/ /usr/local/lib/ruby/2.3.0/
+COPY lib/ /usr/local/lib/ruby/2.5.0/
 
 EXPOSE 9367
 LABEL org.discourse.service._prom-exp.port=9367 org.discourse.service._prom-exp.instance=mobystash org.discourse.mobystash.disable=yes

--- a/Rakefile
+++ b/Rakefile
@@ -56,8 +56,7 @@ namespace :docker do
 
   desc "Build a new docker image"
   task :build do
-    sh "docker pull ruby:2.3-alpine"
-    sh "docker build -t discourse/mobystash --build-arg=http_proxy=#{ENV['http_proxy']} --build-arg=GIT_REVISION=$(git rev-parse HEAD) ."
+    sh "docker build --pull -t discourse/mobystash --build-arg=http_proxy=#{ENV['http_proxy']} --build-arg=GIT_REVISION=$(git rev-parse HEAD) ."
     sh "docker tag discourse/mobystash discourse/mobystash:#{tag}"
   end
 


### PR DESCRIPTION
mobystash must be deployed as a container.  We have full control over
which Ruby we target.  Running tests over a slew of rubies does not
serve much use.

Ruby 2.3 will be EOL soon.  Removing some elements from the Travis build
matrix avoids us burning time on CI environmental problems.  (See #3.)

---

Supersedes https://github.com/discourse/mobystash/pull/3